### PR TITLE
add some fixes and improvements

### DIFF
--- a/scripts/aks-advisor-scan.sh
+++ b/scripts/aks-advisor-scan.sh
@@ -8,15 +8,32 @@
 
 alcide_download_advisor(){
     echo "Downloading Alcide Advisor"
-    curl -o kube-advisor https://alcide.blob.core.windows.net/generic/stable/linux/advisor
-    chmod +x kube-advisor  
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        # Linux
+        local os="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # Mac OSX
+        local os="darwin"
+    else
+        echo "Unsupported OS, Currently Alcide Advisor is supported on Linux or MacOS only"
+        exit
+    fi
+
+    curl -o kube-advisor https://alcide.blob.core.windows.net/generic/stable/$os/advisor
+    chmod +x kube-advisor
 }
 
 alcide_scan_current_cluster(){
     local outdir=$1
+    local CURRENT_CONTEXT=`kubectl config current-context`
 
-    CURRENT_CONTEXT=`kubectl config current-context`
-    alcide_scan_cluster $outdir ${CURRENT_CONTEXT}
+    if [[ $(kubectl auth can-i get po 2> /dev/null) == "yes" ]]; then
+        echo Scanning $cluster
+        alcide_scan_cluster $outdir ${CURRENT_CONTEXT}
+    else
+        echo "The current user doesn't have read permissions to the cluster: ${CURRENT_CONTEXT}"
+    fi
+
 }
 
 alcide_scan_cluster(){
@@ -30,13 +47,13 @@ alcide_scan_cluster(){
 scan_aks_clusters(){
     local outdir=$1
     local CLUSTERS=`az aks list | jq -r '.[] | "\(.name):\(.resourceGroup)" '`
+    local KUBECONFIG=$outdir/advisor-config
 
     for cluster in ${CLUSTERS}
     do
         local cluster_name=`echo $cluster | tr ':' ' ' | awk '{ print $1}'`
         local cluster_rg=`echo $cluster | tr ':' ' '  | awk '{ print $2}'`
 
-        echo Scanning $cluster_name $cluster_rg 
         az aks get-credentials --overwrite-existing --name $cluster_name  --resource-group $cluster_rg
         alcide_scan_current_cluster $outdir $cluster_name
     done  

--- a/scripts/gke-advisor-scan.sh
+++ b/scripts/gke-advisor-scan.sh
@@ -13,15 +13,32 @@ CLUSTER_NAMES=`gcloud container clusters list --sort-by=NUM_NODES 2> /dev/null  
 echo ${CLUSTER_NAMES}
 
 alcide_download_advisor(){
-    curl -o kube-advisor https://alcide.blob.core.windows.net/generic/stable/linux/advisor
-    chmod +x kube-advisor  
+    echo "Downloading Alcide Advisor"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        # Linux
+        local os="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # Mac OSX
+        local os="darwin"
+    else
+        echo "Unsupported OS, Currently Alcide Advisor is supported on Linux or MacOS only"
+        exit
+    fi
+
+    curl -o kube-advisor https://alcide.blob.core.windows.net/generic/stable/$os/advisor
+    chmod +x kube-advisor
 }
 
 alcide_scan_current_cluster(){
     local outdir=$1
+    local CURRENT_CONTEXT=`kubectl config current-context`
 
-    CURRENT_CONTEXT=`kubectl config current-context`
-    alcide_scan_cluster $outdir ${CURRENT_CONTEXT}
+    if [[ $(kubectl auth can-i get po 2> /dev/null) == "yes" ]]; then
+        echo Scanning $cluster
+        alcide_scan_cluster $outdir ${CURRENT_CONTEXT}
+    else
+        echo "The current user doesn't have read permissions to the cluster: ${CURRENT_CONTEXT}"
+    fi
 }
 
 alcide_scan_cluster(){
@@ -34,12 +51,12 @@ alcide_scan_cluster(){
 scan_gke_clusters(){
     local outdir=$1
     local CLUSTER_NAMES=`gcloud container clusters list --sort-by=NUM_NODES 2> /dev/null  | awk '{ print $1 }' | grep -v NAME`
+    local KUBECONFIG=$outdir/advisor-config
 
     #echo ${CLUSTER_NAMES}
     for cluster in ${CLUSTER_NAMES}
     do
-        local region=`gcloud container clusters list --filter=$cluster | awk '{ print $2}' | grep -v LOCATION`
-        echo Scanning $cluster
+        local region=`gcloud container clusters list --filter=name:$cluster | awk '{ print $2}' | grep -v LOCATION`
         gcloud --quiet container clusters get-credentials --region $region $cluster
         alcide_scan_current_cluster $outdir
     done  


### PR DESCRIPTION
1. Add support for MacOS under **_alcide_download_advisor_**
2. Add validation that the current user has access to each cluster under **_alcide_scan_current_cluster_**
3. Set a temporary kube_config file under **_scan_aks_clusters_** (in order to not edit user's default ~/.kube/config file)
4. In GKE script, the query for the region can return more than one line which makes the next command fail (happen in alcide-prod project i.e.).
To fix that I changed _--filter=$cluster_ to _--filter=name:$cluster_ under **_scan_gke_clusters_**

